### PR TITLE
Command handler fixes

### DIFF
--- a/src/main/kotlin/dev/znci/rocket/commands/RocketCommand.kt
+++ b/src/main/kotlin/dev/znci/rocket/commands/RocketCommand.kt
@@ -89,14 +89,12 @@ class RocketCommand(private val plugin: JavaPlugin) : TabExecutor {
         return true
     }
 
-    @Suppress("SENSELESS_COMPARISON")
     override fun onTabComplete(
         sender: CommandSender,
         command: Command,
         label: String,
         args: Array<out String>
     ): MutableList<String>? {
-
         if (!sender.isOp) return null
         if (args.size == 1) {
             return mutableListOf("reload", "disable")

--- a/src/main/kotlin/dev/znci/rocket/commands/RocketCommand.kt
+++ b/src/main/kotlin/dev/znci/rocket/commands/RocketCommand.kt
@@ -41,7 +41,7 @@ class RocketCommand(private val plugin: JavaPlugin) : TabExecutor {
 
         when (action) {
             "reload" -> {
-                if (scriptName.lowercase() == "config") {
+                if (scriptName.lowercase() == "config.lua") {
                     plugin.reloadConfig()
 
                     val defaultLocale = plugin.config.getString("locale", "en_GB").toString()

--- a/src/main/kotlin/dev/znci/rocket/i18n/LocaleManager.kt
+++ b/src/main/kotlin/dev/znci/rocket/i18n/LocaleManager.kt
@@ -81,8 +81,6 @@ object LocaleManager {
             message
         }
 
-        return Component.text(
-            MessageFormatter.formatMessage(formattedMessage)
-        )
+        return MessageFormatter.formatMessage(formattedMessage)
     }
 }

--- a/src/main/kotlin/dev/znci/rocket/i18n/LocaleManager.kt
+++ b/src/main/kotlin/dev/znci/rocket/i18n/LocaleManager.kt
@@ -15,6 +15,7 @@
  */
 package dev.znci.rocket.i18n
 
+import dev.znci.rocket.util.MessageFormatter
 import net.kyori.adventure.text.Component
 import org.bukkit.configuration.file.YamlConfiguration
 import org.bukkit.plugin.java.JavaPlugin
@@ -80,6 +81,8 @@ object LocaleManager {
             message
         }
 
-        return Component.text(formattedMessage.replace("&", "§"))
+        return Component.text(
+            MessageFormatter.formatMessage(formattedMessage)
+        )
     }
 }

--- a/src/main/kotlin/dev/znci/rocket/i18n/LocaleManager.kt
+++ b/src/main/kotlin/dev/znci/rocket/i18n/LocaleManager.kt
@@ -23,7 +23,7 @@ import java.io.File
 
 object LocaleManager {
     private val messages = mutableMapOf<String, Map<String, String>>()
-    private val defaultLang: String = "en_GB"
+    private const val defaultLang: String = "en_GB"
 
     private var plugin: JavaPlugin? = null
     private var lang: String = defaultLang
@@ -56,7 +56,7 @@ object LocaleManager {
         }
     }
 
-    fun getMessage(key: String): String {
+    private fun getMessage(key: String): String {
         val message = messages[lang]?.get(key)
 
         // regex check for {key} in message

--- a/src/main/kotlin/dev/znci/rocket/i18n/LocaleManager.kt
+++ b/src/main/kotlin/dev/znci/rocket/i18n/LocaleManager.kt
@@ -23,10 +23,10 @@ import java.io.File
 
 object LocaleManager {
     private val messages = mutableMapOf<String, Map<String, String>>()
-    private const val defaultLang: String = "en_GB"
+    private const val DEFAULT_LANG: String = "en_GB"
 
     private var plugin: JavaPlugin? = null
-    private var lang: String = defaultLang
+    private var lang: String = DEFAULT_LANG
 
     fun setPlugin(plugin: JavaPlugin) {
         this.plugin = plugin

--- a/src/main/kotlin/dev/znci/rocket/scripting/PlayerManager.kt
+++ b/src/main/kotlin/dev/znci/rocket/scripting/PlayerManager.kt
@@ -43,9 +43,7 @@ object PlayerManager {
         // methods should be defined before properties
         table.set("send", object : OneArgFunction() {
             override fun call(message: LuaValue): LuaValue {
-                val messageComponent = Component.text(
-                    MessageFormatter.formatMessage(message.tojstring())
-                )
+                val messageComponent = MessageFormatter.formatMessage(message.tojstring())
                 player.sendMessage(messageComponent)
                 return LuaValue.TRUE
             }

--- a/src/main/kotlin/dev/znci/rocket/scripting/PlayerManager.kt
+++ b/src/main/kotlin/dev/znci/rocket/scripting/PlayerManager.kt
@@ -18,6 +18,7 @@ package dev.znci.rocket.scripting
 import dev.znci.rocket.scripting.functions.LuaLocation.Companion.fromBukkit
 import dev.znci.rocket.scripting.functions.toBukkitLocation
 import dev.znci.rocket.scripting.util.defineProperty
+import dev.znci.rocket.util.MessageFormatter
 import net.kyori.adventure.text.Component
 import org.bukkit.Bukkit
 import org.bukkit.GameMode
@@ -43,8 +44,7 @@ object PlayerManager {
         table.set("send", object : OneArgFunction() {
             override fun call(message: LuaValue): LuaValue {
                 val messageComponent = Component.text(
-                    message.tojstring()
-                        .replace("&", "§")
+                    MessageFormatter.formatMessage(message.tojstring())
                 )
                 player.sendMessage(messageComponent)
                 return LuaValue.TRUE

--- a/src/main/kotlin/dev/znci/rocket/scripting/classes/Command.kt
+++ b/src/main/kotlin/dev/znci/rocket/scripting/classes/Command.kt
@@ -24,5 +24,6 @@ data class Command(
     var permission: String,
     var permissionMessage: String,
     var aliases: List<String>,
+    var argCount: Int,
     var executor: CommandExecutor
 )

--- a/src/main/kotlin/dev/znci/rocket/scripting/classes/Command.kt
+++ b/src/main/kotlin/dev/znci/rocket/scripting/classes/Command.kt
@@ -22,6 +22,7 @@ data class Command(
     var description: String,
     var usage: String,
     var permission: String,
+    var permissionMessage: String,
     var aliases: List<String>,
     var executor: CommandExecutor
 )

--- a/src/main/kotlin/dev/znci/rocket/scripting/functions/Commands.kt
+++ b/src/main/kotlin/dev/znci/rocket/scripting/functions/Commands.kt
@@ -15,6 +15,8 @@
  */
 package dev.znci.rocket.scripting.functions
 
+import dev.znci.rocket.i18n.LocaleManager
+import dev.znci.rocket.scripting.PermissionsManager
 import dev.znci.rocket.scripting.PlayerManager
 import dev.znci.rocket.scripting.ScriptManager
 import org.bukkit.Bukkit
@@ -98,6 +100,22 @@ class LuaCommands : LuaTable() {
                             commandReference.executor = CommandExecutor { sender, _, _, args ->
                                 val luaArgs = convertArgsToLua(args)
                                 val senderTable = PlayerManager.getPlayerTable(sender as Player)
+
+                                // If the player does not have permission, show the configured no permission message
+                                if (PermissionsManager.hasPermission(sender, commandReference.permission).not()) {
+                                    sender.sendMessage(LocaleManager.getMessageAsComponent("no_permission"))
+                                    return@CommandExecutor true
+                                }
+
+                                println("Command executed by ${sender.name}")
+
+                                // If no arguments are provided, show the usage
+                                if (args.isEmpty()) {
+                                    sender.sendMessage(commandReference.usage)
+                                    return@CommandExecutor true
+                                }
+
+                                println("Arguments: ${args.joinToString(", ")}")
 
                                 luaCallback.call(senderTable, luaArgs)
                                 return@CommandExecutor true

--- a/src/main/kotlin/dev/znci/rocket/scripting/functions/Commands.kt
+++ b/src/main/kotlin/dev/znci/rocket/scripting/functions/Commands.kt
@@ -19,6 +19,7 @@ import dev.znci.rocket.i18n.LocaleManager
 import dev.znci.rocket.scripting.PermissionsManager
 import dev.znci.rocket.scripting.PlayerManager
 import dev.znci.rocket.scripting.ScriptManager
+import dev.znci.rocket.scripting.util.defineProperty
 import dev.znci.rocket.util.MessageFormatter
 import net.kyori.adventure.text.Component
 import org.bukkit.Bukkit
@@ -59,9 +60,7 @@ class LuaCommands : LuaTable() {
                         if (permission != "" && PermissionsManager.hasPermission(sender, permission).not()) {
                             var noPermissionMessage = LocaleManager.getMessageAsComponent("no_permission")
                             if (permissionMessage.isNotEmpty()) {
-                                noPermissionMessage = Component.text(
-                                    MessageFormatter.formatMessage(permissionMessage)
-                                )
+                                noPermissionMessage = MessageFormatter.formatMessage(permissionMessage)
                             }
                             sender.sendMessage(noPermissionMessage)
                             return true
@@ -71,9 +70,7 @@ class LuaCommands : LuaTable() {
                         if (args.isEmpty() && argCount > 0) {
                             var usageMessage = LocaleManager.getMessageAsComponent("invalid_action")
                             if (usage.isNotEmpty()) {
-                                usageMessage = Component.text(
-                                    MessageFormatter.formatMessage(usage)
-                                )
+                                usageMessage = MessageFormatter.formatMessage(usage)
                             }
                             sender.sendMessage(usageMessage)
                             return true
@@ -214,12 +211,12 @@ class LuaCommands : LuaTable() {
                             luaAliases.set(i, LuaValue.valueOf(aliases[i - 1]))
                         }
 
-                        commandTable.set("aliases", luaAliases)
-                        commandTable.set("description", commandReference.description)
-                        commandTable.set("usage", commandReference.usage)
-                        commandTable.set("permission", commandReference.permission)
-                        commandTable.set("permissionMessage", commandReference.permissionMessage)
-                        commandTable.set("argCount", commandReference.argCount)
+                        defineProperty(commandTable, "aliases", { luaAliases })
+                        defineProperty(commandTable, "description", { LuaValue.valueOf(commandReference.description) })
+                        defineProperty(commandTable, "usage", { LuaValue.valueOf(commandReference.usage) })
+                        defineProperty(commandTable, "permission", { LuaValue.valueOf(commandReference.permission) })
+                        defineProperty(commandTable, "permissionMessage", { LuaValue.valueOf(commandReference.permissionMessage) })
+                        defineProperty(commandTable, "argCount", { LuaValue.valueOf(commandReference.argCount) })
 
                         return commandTable
                     }

--- a/src/main/kotlin/dev/znci/rocket/scripting/util/Properties.kt
+++ b/src/main/kotlin/dev/znci/rocket/scripting/util/Properties.kt
@@ -17,10 +17,8 @@ package dev.znci.rocket.scripting.util
 
 import org.luaj.vm2.LuaTable
 import org.luaj.vm2.LuaValue
-import org.luaj.vm2.lib.OneArgFunction
 import org.luaj.vm2.lib.ThreeArgFunction
 import org.luaj.vm2.lib.TwoArgFunction
-import org.luaj.vm2.lib.ZeroArgFunction
 
 fun defineProperty(
     table: LuaTable,

--- a/src/main/kotlin/dev/znci/rocket/util/MessageFormatter.kt
+++ b/src/main/kotlin/dev/znci/rocket/util/MessageFormatter.kt
@@ -1,7 +1,12 @@
 package dev.znci.rocket.util
 
+import net.kyori.adventure.text.Component
+import net.kyori.adventure.text.minimessage.MiniMessage
+
 object MessageFormatter {
-    fun formatMessage(message: String): String {
-        return message.replace("&", "§")
+    fun formatMessage(message: String): Component {
+        val miniMessage = MiniMessage.miniMessage()
+        val messageComponent = miniMessage.deserialize(message)
+        return messageComponent
     }
 }

--- a/src/main/kotlin/dev/znci/rocket/util/MessageFormatter.kt
+++ b/src/main/kotlin/dev/znci/rocket/util/MessageFormatter.kt
@@ -1,0 +1,7 @@
+package dev.znci.rocket.util
+
+object MessageFormatter {
+    fun formatMessage(message: String): String {
+        return message.replace("&", "§")
+    }
+}

--- a/src/main/resources/locales/en_GB.yml
+++ b/src/main/resources/locales/en_GB.yml
@@ -1,3 +1,4 @@
+
 messages:
   bracket_color: "&7"
   bracket_opening_text: "["
@@ -13,9 +14,9 @@ messages:
 
   success_color: "&a"
 
-  invalid_action: "Invalid action."
+  invalid_action: "{error_color}Invalid action."
   usage_template: "{error_color}Usage: "
-
+  
   no_permission: "{error_color}Insufficient permissions."
 
   rocket_command:

--- a/src/main/resources/locales/en_GB.yml
+++ b/src/main/resources/locales/en_GB.yml
@@ -16,7 +16,7 @@ messages:
 
   invalid_action: "{error_color}Invalid action."
   usage_template: "{error_color}Usage: "
-  
+
   no_permission: "{error_color}Insufficient permissions."
 
   rocket_command:

--- a/src/main/resources/locales/en_GB.yml
+++ b/src/main/resources/locales/en_GB.yml
@@ -15,6 +15,9 @@ messages:
 
   invalid_action: "Invalid action."
   usage_template: "{error_color}Usage: "
+
+  no_permission: "{error_color}Insufficient permissions."
+
   rocket_command:
     usage: "{prefix_error} {usage_template}/rocket <reload|disable> <script_name|config>"
     scripts_folder_not_found: "{prefix} {error_color}Scripts folder not found."


### PR DESCRIPTION
This PR adds/fixes:

1. Usage and permission messages now use correct color formatting (`§` -> `&`)
2. Custom permission messages
3. A global message formatter (inside `MessageFormatter`)
4. A new locale string `no_permission`